### PR TITLE
Add url_prefix parameter

### DIFF
--- a/flask_sandboy/__init__.py
+++ b/flask_sandboy/__init__.py
@@ -19,19 +19,20 @@ __version__ = '0.0.3'
 
 class Sandboy(object):
     """Main object for injecting RESTful HTTP endpoint."""
-    def __init__(self, app, db, models):
+    def __init__(self, app, db, models, url_prefix=None):
         """Initialize and register the given *models*."""
         self.app = app
         self.db = db
         app.extensions['sandboy'] = self
         self.blueprint = None
+        self.url_prefix = url_prefix
         self.init_app(app, models)
 
     def init_app(self, app, models):
         """Initialize and register error handlers."""
 
         # pylint: disable=unused-variable
-        self.blueprint = Blueprint('sandboy', __name__)
+        self.blueprint = Blueprint('sandboy', __name__, url_prefix=self.url_prefix)
 
         @self.blueprint.errorhandler(BadRequestException)
         @self.blueprint.errorhandler(ForbiddenException)

--- a/flask_sandboy/service.py
+++ b/flask_sandboy/service.py
@@ -6,7 +6,7 @@ from flask_sandboy.models import verify_fields
 from flask_sandboy.exception import NotFoundException
 
 
-class Service(MethodView):
+class ReadService(MethodView):
     """Base class for all resources."""
 
     __model__ = None
@@ -31,6 +31,16 @@ class Service(MethodView):
                 int(request.args['page'])).items
         return jsonify(
             {'resources': [resource.to_dict() for resource in resources]})
+
+    def _resource(self, resource_id):
+        """Return resource represented by this *resource_id*."""
+        resource = self.__db__.session.query(self.__model__).get(resource_id)
+        if not resource:
+            return None
+        return resource
+
+
+class WriteService(ReadService):
 
     @verify_fields
     def post(self, resource_id=None):
@@ -75,12 +85,6 @@ class Service(MethodView):
         self.__db__.session.commit()
         return self._created_response(resource.to_dict())
 
-    def _resource(self, resource_id):
-        """Return resource represented by this *resource_id*."""
-        resource = self.__db__.session.query(self.__model__).get(resource_id)
-        if not resource:
-            return None
-        return resource
 
     @staticmethod
     def _no_content_response():


### PR DESCRIPTION
Sometimes you just don't want your model names in the root of your app URL. Especially when you have already used some of the names :)

Also, add a readonly mode.
