### PR TITLE
verify_fields(): columns that have defaults or are nullable are allowed to pass

### DIFF
--- a/flask_sandboy/__init__.py
+++ b/flask_sandboy/__init__.py
@@ -19,11 +19,11 @@ __version__ = '0.0.3'
 
 class Sandboy(object):
     """Main object for injecting RESTful HTTP endpoint."""
-    def __init__(self, app, db, models, url_prefix=None, readonly=False):
+    def __init__(self, app, db, models, url_prefix=None, readonly=False, extension_name='sandboy'):
         """Initialize and register the given *models*."""
         self.app = app
         self.db = db
-        app.extensions['sandboy'] = self
+        app.extensions[extension_name] = self
         self.blueprint = None
         self.url_prefix = url_prefix
         self.readonly = readonly
@@ -33,7 +33,7 @@ class Sandboy(object):
         """Initialize and register error handlers."""
 
         # pylint: disable=unused-variable
-        self.blueprint = Blueprint('sandboy', __name__, url_prefix=self.url_prefix)
+        self.blueprint = Blueprint(extension_name, __name__, url_prefix=self.url_prefix)
 
         @self.blueprint.errorhandler(BadRequestException)
         @self.blueprint.errorhandler(ForbiddenException)

--- a/flask_sandboy/__init__.py
+++ b/flask_sandboy/__init__.py
@@ -27,13 +27,14 @@ class Sandboy(object):
         self.blueprint = None
         self.url_prefix = url_prefix
         self.readonly = readonly
+        self.extension_name = extension_name
         self.init_app(app, models)
 
     def init_app(self, app, models):
         """Initialize and register error handlers."""
 
         # pylint: disable=unused-variable
-        self.blueprint = Blueprint(extension_name, __name__, url_prefix=self.url_prefix)
+        self.blueprint = Blueprint(self.extension_name, __name__, url_prefix=self.url_prefix)
 
         @self.blueprint.errorhandler(BadRequestException)
         @self.blueprint.errorhandler(ForbiddenException)

--- a/flask_sandboy/models.py
+++ b/flask_sandboy/models.py
@@ -41,7 +41,7 @@ def verify_fields(function):
             raise BadRequestException("No data received from request")
         for required in instance.__model__.__table__.columns:
             if required.name in (
-                    instance.__model__.__table__.primary_key.columns) or required.default:
+                    instance.__model__.__table__.primary_key.columns) or required.default or required.nullable is True:
                 continue
             if required.name not in data:
                 raise ForbiddenException('{} required'.format(required))

--- a/flask_sandboy/models.py
+++ b/flask_sandboy/models.py
@@ -41,7 +41,7 @@ def verify_fields(function):
             raise BadRequestException("No data received from request")
         for required in instance.__model__.__table__.columns:
             if required.name in (
-                    instance.__model__.__table__.primary_key.columns):
+                    instance.__model__.__table__.primary_key.columns) or required.default:
                 continue
             if required.name not in data:
                 raise ForbiddenException('{} required'.format(required))


### PR DESCRIPTION
Better out of the box experience for columns with default values or allowed to be null.

It would be cool to support validators, but it's messy because of the need for SQLAlchemy's ctx.
