### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/jeffknupp/flask_sandboy.svg?branch=develop)](https://travis-ci.org/jeffknupp/flask_sandboy)
 [![Coverage Status](https://coveralls.io/repos/jeffknupp/flask_sandboy/badge.png)](https://coveralls.io/r/jeffknupp/flask_sandboy)
-[![Downloads](https://pypip.in/download/flask_sandboy/badge.png)](https://pypi.python.org/pypi/flask_sandboy/)
-[![Latest Version](https://pypip.in/version/flask_sandboy/badge.png)](https://pypi.python.org/pypi/flask_sandboy/)
+[![Downloads](https://img.shields.io/pypi/dm/flask_sandboy.svg)](https://pypi.python.org/pypi/flask_sandboy/)
+[![Latest Version](https://img.shields.io/pypi/v/flask_sandboy.svg)](https://pypi.python.org/pypi/flask_sandboy/)
 
 Flask-Sandboy is [sandman's](http://www.github.com/jeffknupp/sandman) litte
 brother. Like `sandman`, Flask-Sandboy automatically generates REST APIs. Unlike


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20flask-sandboy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `flask-sandboy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.